### PR TITLE
Fix Nondeterministic Ordering in Tests 

### DIFF
--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -26,11 +26,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneRules;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -487,6 +483,13 @@ public class AbstractTest {
     return TABLES.get(array, () -> {
       Class<?> clazz = array.getClass().getComponentType();
       Field[] fields = getInstanceFields(clazz);
+
+      Arrays.sort(fields, (o1, o2) -> {
+        Ordinal or1 = o1.getAnnotation(Ordinal.class);
+        Ordinal or2 = o2.getAnnotation(Ordinal.class);
+        return or1.value() - or2.value();
+      });
+
       List<Object[]> result = new ArrayList<>(array.length);
       for (int i = 0; i < array.length; i++) {
         Object[] temp = new Object[fields.length];


### PR DESCRIPTION
18 tests from com.alibaba.innodb.java.reader.sk.SimpleSkTableReaderTest are flaky.

If java.lang.Object.getDeclaredFields() returns the fields in a different order multiple tests could fail. This PR ensures that the tests pass even if the order changes.

To guarantee the ordering of com.alibaba.innodb.java.reader.getAllRows(...), I've added annotations to Employee class and Department class to sort the fields by their annotated values.

As per https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--
"The elements in the returned array are not sorted and are not in any particular order."