### PR TITLE
Fix Nondeterministic Ordering in Tests Part 2

### DIFF
--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -523,16 +523,13 @@ public class AbstractTest {
   }
 
   protected static int getFieldOrdinal(Class<?> clazz, String fieldName) {
-    int ordinal = 0;
-    Field[] fields = clazz.getDeclaredFields();
-    for (Field field : fields) {
-      if (field.getName().equals(fieldName)) {
-        return ordinal;
-      }
-      ++ordinal;
+    try {
+      Field field = clazz.getDeclaredField(fieldName);
+      Ordinal order = field.getAnnotation(Ordinal.class);
+      return order.value();
+    } catch (NoSuchFieldException e) {
+      return -1;
     }
-
-    return -1;
   }
 
   protected static boolean hasSuperClass(Class<?> clazz) {


### PR DESCRIPTION
27 other tests from com.alibaba.innodb.java.reader.sk.SimpleSkTableReaderTest are flaky.

If java.lang.Object.getDeclaredFields() returns the fields in a different order multiple tests could fail. This PR ensures that the tests pass even if the order changes.

To guarantee the ordering of com.alibaba.innodb.java.reader.getFieldOrdinal(...), I've added annotations, PR: chrnndz3#1, to Employee class and Department class to retrieve the field ordinal using the field annotations instead of iterating through getDeclaredField() which is nondeterministic.

As per https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--